### PR TITLE
translation: add Spanish translations for AI guides

### DIFF
--- a/adev-es/src/content/ai/design-patterns.en.md
+++ b/adev-es/src/content/ai/design-patterns.en.md
@@ -1,0 +1,172 @@
+# Design patterns for AI SDKs and signal APIs
+
+Interacting with AI and Large Language Model (LLM) APIs introduces unique challenges, such as managing asynchronous operations, handling streaming data, and designing a responsive user experience for potentially slow or unreliable network requests. Angular [signals](guide/signals) and the [`resource`](guide/signals/resource) API provide powerful tools to solve these problems elegantly.
+
+## Triggering requests with signals
+
+A common pattern when working with user-provided prompts is to separate the user's live input from the submitted value that triggers the API call.
+
+1. Store the user's raw input in one signal as they type
+2. When the user submits (e.g., by clicking a button), update a second signal with contents of the first signal.
+3. Use the second signal in the **`params`** field of your `resource`.
+
+This setup ensures the resource's **`loader`** function only runs when the user explicitly submits their prompt, not on every keystroke. You can use additional signal parameters, like a `sessionId` or `userId` (which can be useful for creating persistent LLM sessions), in the `loader` field. This way, the request always uses these parameters' current values without re-triggering the asynchronous function defined in the `loader` field.
+
+Many AI SDKs provide helper methods for making API calls. For example, the Genkit client library exposes a `runFlow` method for calling Genkit flows, which you can call from a resource's `loader`. For other APIs, you can use the [`httpResource`](guide/signals/resource#reactive-data-fetching-with-httpresource).
+
+The following example shows a `resource` that fetches parts of an AI-generated story. The `loader` is triggered only when the `storyInput` signal changes.
+
+```ts
+// A resource that fetches three parts of an AI generated story
+storyResource = resource({
+  // The default value to use before the first request or on error
+  defaultValue: DEFAULT_STORY,
+  // The loader is re-triggered when this signal changes
+  params: () => this.storyInput(),
+  // The async function to fetch data
+  loader: ({params}): Promise<StoryData> => {
+    // The params value is the current value of the storyInput signal
+    const url = this.endpoint();
+    return runFlow({ url, input: {
+      userInput: params,
+      sessionId: this.storyService.sessionId() // Read from another signal
+    }});
+  }
+});
+```
+
+## Preparing LLM data for templates
+
+You can configure LLM APIs to return structured data. Strongly typing your `resource` to match the expected output from the LLM provides better type safety and editor autocompletion.
+
+To manage state derived from a resource, use a `computed` signal or `linkedSignal`. Because `linkedSignal` [provides access to prior values](guide/signals/linked-signal), it can serve a variety of AI-related use cases, including
+  * building a chat history
+  * preserving or customizing data that templates display while LLMs generate content
+
+In the example below, `storyParts` is a `linkedSignal` that appends the latest story parts returned from `storyResource` to the existing array of story parts.
+
+```ts
+storyParts = linkedSignal<string[], string[]>({
+  // The source signal that triggers the computation
+  source: () => this.storyResource.value().storyParts,
+  // The computation function
+  computation: (newStoryParts, previous) => {
+    // Get the previous value of this linkedSignal, or an empty array
+    const existingStoryParts = previous?.value || [];
+    // Return a new array with the old and new parts
+    return [...existingStoryParts, ...newStoryParts];
+  }
+});
+```
+
+## Performance and user experience
+
+LLM APIs may be slower and more error-prone than conventional, more deterministic APIs. You can use several Angular features to build a performant and user-friendly interface.
+
+* **Scoped Loading:** place the `resource` in the component that directly uses the data. This helps limit change detection cycles (especially in zoneless applications) and prevents blocking other parts of your application. If data needs to be shared across multiple components, provide the `resource` from a service.  
+* **SSR and Hydration:** use Server-Side Rendering (SSR) with incremental hydration to render the initial page content quickly. You can show a placeholder for the AI-generated content and defer fetching the data until the component hydrates on the client.  
+* **Loading State:** use the `resource` `LOADING` [status](guide/signals/resource#resource-status) to show an indicator, like a spinner, while the request is in flight. This status covers both initial loads and reloads.  
+* **Error Handling and Retries:** use the `resource` [**`reload()`**](guide/signals/resource#reloading) method as a simple way for users to retry failed requests, may be more prevalent when relying on AI generated content.
+
+The following example demonstrates how to create a responsive UI to dynamically display an AI generated image with loading and retry functionality.
+
+```angular-html
+<!-- Display a loading spinner while the LLM generates the image -->
+@if (imgResource.isLoading()) {
+  <div class="img-placeholder">
+    <mat-spinner [diameter]="50" />
+  </div>
+<!-- Dynamically populates the src attribute with the generated image URL -->
+} @else if (imgResource.hasValue()) {
+  <img [src]="imgResource.value()" />
+<!-- Provides a retry option if the request fails  -->
+} @else {
+  <div class="img-placeholder" (click)="imgResource.reload()">
+    <mat-icon fontIcon="refresh" />
+      <p>Failed to load image. Click to retry.</p>
+  </div>
+}
+```
+
+
+## AI patterns in action: streaming chat responses
+Interfaces often display partial results from LLM-based APIs incrementally as response data arrives. Angular's resource API provides the ability to stream responses to support this type of pattern. The `stream` property of `resource` accepts an asynchronous function you can use to apply updates to a signal value over time. The signal being updated represents the data being streamed.
+
+```ts
+characters = resource({
+  stream: async () => {
+    const data = signal<ResourceStreamItem<string>>({value: ''});
+    // Calls a Genkit streaming flow using the streamFlow method
+    // exposed by the Genkit client SDK
+    const response = streamFlow({
+      url: '/streamCharacters',
+      input: 10
+    });
+
+    (async () => {
+      for await (const chunk of response.stream) {
+        data.update((prev) => {
+          if ('value' in prev) {
+            return { value: `${prev.value} ${chunk}` };
+          } else {
+            return { error: chunk as unknown as Error };
+          }
+        });
+      }
+    })();
+
+    return data;
+  }
+});
+```
+
+The `characters` member is updated asynchronously and can be displayed in the template.
+
+```angular-html
+@if (characters.isLoading()) {
+  <p>Loading...</p>
+} @else if (characters.hasValue()) {
+  <p>{{characters.value()}}</p>
+} @else {
+  <p>{{characters.error()}}</p>
+}
+```
+
+On the server side, in `server.ts` for example, the defined endpoint sends the data to be streamed to the client. The following code uses Gemini with the Genkit framework but this technique is applicable to other APIs that support streaming responses from LLMs:
+
+```ts
+import { startFlowServer } from '@genkit-ai/express';
+import { genkit } from "genkit/beta";
+import { googleAI, gemini20Flash } from "@genkit-ai/googleai";
+
+const ai = genkit({ plugins: [googleAI()] });
+
+export const streamCharacters = ai.defineFlow({
+    name: 'streamCharacters',
+    inputSchema: z.number(),
+    outputSchema: z.string(),
+    streamSchema: z.string(),
+  },
+  async (count, { sendChunk }) => {
+    const { response, stream } = ai.generateStream({
+    model: gemini20Flash,
+    config: {
+      temperature: 1,
+    },
+    prompt: `Generate ${count} different RPG game characters.`,
+  });
+
+  (async () => {
+    for await (const chunk of stream) {
+      sendChunk(chunk.content[0].text!);
+    }
+  })();
+
+  return (await response).text;
+});
+
+startFlowServer({
+  flows: [streamCharacters],
+});
+
+```

--- a/adev-es/src/content/ai/design-patterns.md
+++ b/adev-es/src/content/ai/design-patterns.md
@@ -1,103 +1,103 @@
-# Design patterns for AI SDKs and signal APIs
+# Patrones de diseño para SDKs de IA y APIs de signals
 
-Interacting with AI and Large Language Model (LLM) APIs introduces unique challenges, such as managing asynchronous operations, handling streaming data, and designing a responsive user experience for potentially slow or unreliable network requests. Angular [signals](guide/signals) and the [`resource`](guide/signals/resource) API provide powerful tools to solve these problems elegantly.
+Interactuar con APIs de IA y Modelos de Lenguaje Grandes (LLM) introduce desafíos únicos, como gestionar operaciones asíncronas, manejar datos en streaming y diseñar una experiencia de usuario responsiva para solicitudes de red potencialmente lentas o poco confiables. Los [signals](guide/signals) de Angular y la API [`resource`](guide/signals/resource) proporcionan herramientas poderosas para resolver estos problemas de manera elegante.
 
-## Triggering requests with signals
+## Disparando solicitudes con signals
 
-A common pattern when working with user-provided prompts is to separate the user's live input from the submitted value that triggers the API call.
+Un patrón común al trabajar con prompts proporcionados por el usuario es separar la entrada en vivo del usuario del valor enviado que dispara la llamada a la API.
 
-1. Store the user's raw input in one signal as they type
-2. When the user submits (e.g., by clicking a button), update a second signal with contents of the first signal.
-3. Use the second signal in the **`params`** field of your `resource`.
+1. Almacena la entrada sin procesar del usuario en un signal mientras escribe
+2. Cuando el usuario envía (por ejemplo, al hacer clic en un botón), actualiza un segundo signal con el contenido del primer signal.
+3. Usa el segundo signal en el campo **`params`** de tu `resource`.
 
-This setup ensures the resource's **`loader`** function only runs when the user explicitly submits their prompt, not on every keystroke. You can use additional signal parameters, like a `sessionId` or `userId` (which can be useful for creating persistent LLM sessions), in the `loader` field. This way, the request always uses these parameters' current values without re-triggering the asynchronous function defined in the `loader` field.
+Esta configuración asegura que la función **`loader`** del resource solo se ejecute cuando el usuario envía explícitamente su prompt, no en cada pulsación de tecla. Puedes usar parámetros de signal adicionales, como un `sessionId` o `userId` (que pueden ser útiles para crear sesiones persistentes de LLM), en el campo `loader`. De esta manera, la solicitud siempre usa los valores actuales de estos parámetros sin volver a disparar la función asíncrona definida en el campo `loader`.
 
-Many AI SDKs provide helper methods for making API calls. For example, the Genkit client library exposes a `runFlow` method for calling Genkit flows, which you can call from a resource's `loader`. For other APIs, you can use the [`httpResource`](guide/signals/resource#reactive-data-fetching-with-httpresource).
+Muchos SDKs de IA proporcionan métodos auxiliares para hacer llamadas a la API. Por ejemplo, la biblioteca cliente de Genkit expone un método `runFlow` para llamar flows de Genkit, que puedes llamar desde el `loader` de un resource. Para otras APIs, puedes usar el [`httpResource`](guide/signals/resource#reactive-data-fetching-with-httpresource).
 
-The following example shows a `resource` that fetches parts of an AI-generated story. The `loader` is triggered only when the `storyInput` signal changes.
+El siguiente ejemplo muestra un `resource` que obtiene partes de una historia generada por IA. El `loader` se dispara solo cuando el signal `storyInput` cambia.
 
 ```ts
-// A resource that fetches three parts of an AI generated story
+// Un resource que obtiene tres partes de una historia generada por IA
 storyResource = resource({
-  // The default value to use before the first request or on error
+  // El valor predeterminado a usar antes de la primera solicitud o en caso de error
   defaultValue: DEFAULT_STORY,
-  // The loader is re-triggered when this signal changes
+  // El loader se vuelve a disparar cuando este signal cambia
   params: () => this.storyInput(),
-  // The async function to fetch data
+  // La función asíncrona para obtener datos
   loader: ({params}): Promise<StoryData> => {
-    // The params value is the current value of the storyInput signal
+    // El valor de params es el valor actual del signal storyInput
     const url = this.endpoint();
     return runFlow({ url, input: {
       userInput: params,
-      sessionId: this.storyService.sessionId() // Read from another signal
+      sessionId: this.storyService.sessionId() // Lee desde otro signal
     }});
   }
 });
 ```
 
-## Preparing LLM data for templates
+## Preparando datos de LLM para plantillas
 
-You can configure LLM APIs to return structured data. Strongly typing your `resource` to match the expected output from the LLM provides better type safety and editor autocompletion.
+Puedes configurar APIs de LLM para que devuelvan datos estructurados. Tipar fuertemente tu `resource` para que coincida con la salida esperada del LLM proporciona mejor seguridad de tipos y autocompletado del editor.
 
-To manage state derived from a resource, use a `computed` signal or `linkedSignal`. Because `linkedSignal` [provides access to prior values](guide/signals/linked-signal), it can serve a variety of AI-related use cases, including
-  * building a chat history
-  * preserving or customizing data that templates display while LLMs generate content
+Para gestionar estado derivado de un resource, usa un signal `computed` o `linkedSignal`. Dado que `linkedSignal` [proporciona acceso a valores previos](guide/signals/linked-signal), puede servir una variedad de casos de uso relacionados con IA, incluyendo
+  * construir un historial de chat
+  * preservar o personalizar datos que las plantillas muestran mientras los LLMs generan contenido
 
-In the example below, `storyParts` is a `linkedSignal` that appends the latest story parts returned from `storyResource` to the existing array of story parts.
+En el ejemplo a continuación, `storyParts` es un `linkedSignal` que agrega las últimas partes de la historia devueltas desde `storyResource` al array existente de partes de la historia.
 
 ```ts
 storyParts = linkedSignal<string[], string[]>({
-  // The source signal that triggers the computation
+  // El signal fuente que dispara el cálculo
   source: () => this.storyResource.value().storyParts,
-  // The computation function
+  // La función de cálculo
   computation: (newStoryParts, previous) => {
-    // Get the previous value of this linkedSignal, or an empty array
+    // Obtener el valor previo de este linkedSignal, o un array vacío
     const existingStoryParts = previous?.value || [];
-    // Return a new array with the old and new parts
+    // Devolver un nuevo array con las partes antiguas y nuevas
     return [...existingStoryParts, ...newStoryParts];
   }
 });
 ```
 
-## Performance and user experience
+## Rendimiento y experiencia de usuario
 
-LLM APIs may be slower and more error-prone than conventional, more deterministic APIs. You can use several Angular features to build a performant and user-friendly interface.
+Las APIs de LLM pueden ser más lentas y más propensas a errores que las APIs convencionales, más determinísticas. Puedes usar varias características de Angular para construir una interfaz eficiente y amigable para el usuario.
 
-* **Scoped Loading:** place the `resource` in the component that directly uses the data. This helps limit change detection cycles (especially in zoneless applications) and prevents blocking other parts of your application. If data needs to be shared across multiple components, provide the `resource` from a service.  
-* **SSR and Hydration:** use Server-Side Rendering (SSR) with incremental hydration to render the initial page content quickly. You can show a placeholder for the AI-generated content and defer fetching the data until the component hydrates on the client.  
-* **Loading State:** use the `resource` `LOADING` [status](guide/signals/resource#resource-status) to show an indicator, like a spinner, while the request is in flight. This status covers both initial loads and reloads.  
-* **Error Handling and Retries:** use the `resource` [**`reload()`**](guide/signals/resource#reloading) method as a simple way for users to retry failed requests, may be more prevalent when relying on AI generated content.
+* **Carga Acotada:** coloca el `resource` en el componente que directamente usa los datos. Esto ayuda a limitar los ciclos de detección de cambios (especialmente en aplicaciones zoneless) y previene bloquear otras partes de tu aplicación. Si los datos necesitan ser compartidos entre múltiples componentes, proporciona el `resource` desde un servicio.
+* **SSR e Hidratación:** usa Server-Side Rendering (SSR) con hidratación incremental para renderizar el contenido inicial de la página rápidamente. Puedes mostrar un placeholder para el contenido generado por IA y diferir la obtención de datos hasta que el componente se hidrate en el cliente.
+* **Estado de Carga:** usa el [estado](guide/signals/resource#resource-status) `LOADING` del `resource` para mostrar un indicador, como un spinner, mientras la solicitud está en curso. Este estado cubre tanto cargas iniciales como recargas.
+* **Manejo de Errores y Reintentos:** usa el método [**`reload()`**](guide/signals/resource#reloading) del `resource` como una forma simple para que los usuarios reintenten solicitudes fallidas, que pueden ser más prevalentes al depender de contenido generado por IA.
 
-The following example demonstrates how to create a responsive UI to dynamically display an AI generated image with loading and retry functionality.
+El siguiente ejemplo demuestra cómo crear una interfaz de usuario responsiva para mostrar dinámicamente una imagen generada por IA con funcionalidad de carga y reintento.
 
 ```angular-html
-<!-- Display a loading spinner while the LLM generates the image -->
+<!-- Mostrar un spinner de carga mientras el LLM genera la imagen -->
 @if (imgResource.isLoading()) {
   <div class="img-placeholder">
     <mat-spinner [diameter]="50" />
   </div>
-<!-- Dynamically populates the src attribute with the generated image URL -->
+<!-- Puebla dinámicamente el atributo src con la URL de la imagen generada -->
 } @else if (imgResource.hasValue()) {
   <img [src]="imgResource.value()" />
-<!-- Provides a retry option if the request fails  -->
+<!-- Proporciona una opción de reintento si la solicitud falla  -->
 } @else {
   <div class="img-placeholder" (click)="imgResource.reload()">
     <mat-icon fontIcon="refresh" />
-      <p>Failed to load image. Click to retry.</p>
+      <p>Falló la carga de la imagen. Haz clic para reintentar.</p>
   </div>
 }
 ```
 
 
-## AI patterns in action: streaming chat responses
-Interfaces often display partial results from LLM-based APIs incrementally as response data arrives. Angular's resource API provides the ability to stream responses to support this type of pattern. The `stream` property of `resource` accepts an asynchronous function you can use to apply updates to a signal value over time. The signal being updated represents the data being streamed.
+## Patrones de IA en acción: streaming de respuestas de chat
+Las interfaces a menudo muestran resultados parciales de APIs basadas en LLM de forma incremental a medida que llegan los datos de respuesta. La API de resource de Angular proporciona la capacidad de hacer streaming de respuestas para soportar este tipo de patrón. La propiedad `stream` de `resource` acepta una función asíncrona que puedes usar para aplicar actualizaciones a un valor de signal a lo largo del tiempo. El signal que se está actualizando representa los datos que se están transmitiendo en streaming.
 
 ```ts
 characters = resource({
   stream: async () => {
     const data = signal<ResourceStreamItem<string>>({value: ''});
-    // Calls a Genkit streaming flow using the streamFlow method
-    // exposed by the Genkit client SDK
+    // Llama a un flow de streaming de Genkit usando el método streamFlow
+    // expuesto por el SDK cliente de Genkit
     const response = streamFlow({
       url: '/streamCharacters',
       input: 10
@@ -120,11 +120,11 @@ characters = resource({
 });
 ```
 
-The `characters` member is updated asynchronously and can be displayed in the template.
+El miembro `characters` se actualiza asincrónicamente y puede mostrarse en la plantilla.
 
 ```angular-html
 @if (characters.isLoading()) {
-  <p>Loading...</p>
+  <p>Cargando...</p>
 } @else if (characters.hasValue()) {
   <p>{{characters.value()}}</p>
 } @else {
@@ -132,7 +132,7 @@ The `characters` member is updated asynchronously and can be displayed in the te
 }
 ```
 
-On the server side, in `server.ts` for example, the defined endpoint sends the data to be streamed to the client. The following code uses Gemini with the Genkit framework but this technique is applicable to other APIs that support streaming responses from LLMs:
+En el lado del servidor, en `server.ts` por ejemplo, el endpoint definido envía los datos para ser transmitidos en streaming al cliente. El siguiente código usa Gemini con el framework Genkit pero esta técnica es aplicable a otras APIs que soporten respuestas en streaming de LLMs:
 
 ```ts
 import { startFlowServer } from '@genkit-ai/express';

--- a/adev-es/src/content/ai/develop-with-ai.en.md
+++ b/adev-es/src/content/ai/develop-with-ai.en.md
@@ -1,0 +1,45 @@
+# LLM prompts and AI IDE setup
+Generating code with large language models (LLMs) is a rapidly growing area of interest for developers. While LLMs are often capable of generating working code it can be a challenge to generate code for consistently evolving frameworks like Angular.
+
+Advanced instructions and prompting are an emerging standard for supporting modern code generation with domain specific details. This section contains curated content and resources to support more accurate code generation for Angular and LLMs.
+
+## Custom Prompts and System Instructions
+Improve your experience generating code with LLMs by using one of the following custom, domain specific files.
+
+NOTE: These files will be updated on a regular basis staying up to date with Angular's conventions.
+
+Here is a set of instructions to help LLMs generate correct code that follows Angular best practices. This file can be included as system instructions to your AI tooling or included along with your prompt as context.
+
+<docs-code language="md" path="adev/src/context/best-practices.md" class="compact"/>
+
+<a download href="/assets/context/best-practices.md" target="_blank">Click here to download the best-practices.md file.</a> 
+
+## Rules Files
+Several editors, such as <a href="https://studio.firebase.google.com?utm_source=adev&utm_medium=website&utm_campaign=BUILD_WITH_AI_ANGULAR&utm_term=angular_devrel&utm_content=build_with_ai_angular_firebase_studio">Firebase Studio</a> have rules files useful for providing critical context to LLMs.
+
+| Environment/IDE | Rules File                                                      | Installation Instructions                                                                                              |
+|:----------------|:----------------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------|
+| Firebase Studio | <a download href="/assets/context/airules.md" target="_blank">airules.md</a>    | <a href="https://firebase.google.com/docs/studio/set-up-gemini#custom-instructions">Configure `airules.md`</a>         |
+| Copilot powered IDEs | <a download="copilot-instructions.md" href="/assets/context/guidelines.md" target="_blank">copilot-instructions.md</a>  | <a href="https://code.visualstudio.com/docs/copilot/copilot-customization#_custom-instructions" target="_blank">Configure `.github/copilot-instructions.md`</a> |
+| Cursor          | <a download href="/assets/context/angular-20.mdc" target="_blank">cursor.md</a> | <a href="https://docs.cursor.com/context/rules" target="_blank">Configure `cursorrules.md`</a>                         |
+| JetBrains IDEs  | <a download href="/assets/context/guidelines.md" target="_blank">guidelines.md</a>  | <a href="https://www.jetbrains.com/help/junie/customize-guidelines.html" target="_blank">Configure `guidelines.md`</a> |
+| VS Code | <a download=".instructions.md" href="/assets/context/guidelines.md" target="_blank">.instructions.md</a>  | <a href="https://code.visualstudio.com/docs/copilot/copilot-customization#_custom-instructions" target="_blank">Configure `.instructions.md`</a> |
+| Windsurf | <a download href="/assets/context/guidelines.md" target="_blank">guidelines.md</a>  | <a href="https://docs.windsurf.com/windsurf/cascade/memories#rules" target="_blank">Configure `guidelines.md`</a> |
+
+## Angular CLI MCP Server setup
+The Angular CLI includes an experimental [Model Context Protocol (MCP) server](https://modelcontextprotocol.io/) that allows AI assistants in your development environment to interact with the Angular CLI.
+
+[**Learn how to set up the Angular CLI MCP Server**](/ai/mcp)
+
+## Providing Context with `llms.txt`
+`llms.txt` is a proposed standard for websites designed to help LLMs better understand and process their content. The Angular team has developed two versions of this file to help LLMs and tools that use LLMs for code generation to create better modern Angular code.
+
+
+* <a href="/llms.txt" target="_blank">llms.txt</a> - an index file providing links to key files and resources. 
+* <a href="/context/llm-files/llms-full.txt" target="_blank">llms-full.txt</a> - a more robust compiled set of resources describing how Angular works and how to build Angular applications.
+
+Be sure [to check out the overview page](/ai) for more information on how to integrate AI into your Angular applications.
+
+## Web Codegen Scorer
+The Angular team developed and open-sourced the [Web Codegen Scorer](https://github.com/angular/web-codegen-scorer), a tool to evaluate and score the quality of AI generated web code. You can use this tool to make evidence-based decisions relating to AI-generated code, such as fine-tuning prompts to improve the accuracy of LLM-generated code for Angular. These prompts can be included as system instructions for your AI tooling or as context with your prompt. You can also use this tool to compare the quality of code produced by different models and monitor quality over time as models and agents evolve.
+

--- a/adev-es/src/content/ai/develop-with-ai.md
+++ b/adev-es/src/content/ai/develop-with-ai.md
@@ -1,45 +1,45 @@
-# LLM prompts and AI IDE setup
-Generating code with large language models (LLMs) is a rapidly growing area of interest for developers. While LLMs are often capable of generating working code it can be a challenge to generate code for consistently evolving frameworks like Angular.
+# Prompts de LLM y configuración de IDE con IA
+Generar código con modelos de lenguaje grandes (LLMs) es un área de interés en rápido crecimiento para los desarrolladores. Aunque los LLMs a menudo son capaces de generar código funcional, puede ser un desafío generar código para frameworks en constante evolución como Angular.
 
-Advanced instructions and prompting are an emerging standard for supporting modern code generation with domain specific details. This section contains curated content and resources to support more accurate code generation for Angular and LLMs.
+Las instrucciones avanzadas y el prompting son un estándar emergente para soportar la generación de código moderna con detalles específicos del dominio. Esta sección contiene contenido y recursos curados para apoyar una generación de código más precisa para Angular y LLMs.
 
-## Custom Prompts and System Instructions
-Improve your experience generating code with LLMs by using one of the following custom, domain specific files.
+## Prompts Personalizados e Instrucciones del Sistema
+Mejora tu experiencia generando código con LLMs usando uno de los siguientes archivos personalizados, específicos del dominio.
 
-NOTE: These files will be updated on a regular basis staying up to date with Angular's conventions.
+NOTA: Estos archivos se actualizarán regularmente manteniéndose al día con las convenciones de Angular.
 
-Here is a set of instructions to help LLMs generate correct code that follows Angular best practices. This file can be included as system instructions to your AI tooling or included along with your prompt as context.
+Aquí hay un conjunto de instrucciones para ayudar a los LLMs a generar código correcto que sigue las mejores prácticas de Angular. Este archivo puede incluirse como instrucciones del sistema para tus herramientas de IA o incluirse junto con tu prompt como contexto.
 
 <docs-code language="md" path="adev/src/context/best-practices.md" class="compact"/>
 
-<a download href="/assets/context/best-practices.md" target="_blank">Click here to download the best-practices.md file.</a> 
+<a download href="/assets/context/best-practices.md" target="_blank">Haz clic aquí para descargar el archivo best-practices.md.</a>
 
-## Rules Files
-Several editors, such as <a href="https://studio.firebase.google.com?utm_source=adev&utm_medium=website&utm_campaign=BUILD_WITH_AI_ANGULAR&utm_term=angular_devrel&utm_content=build_with_ai_angular_firebase_studio">Firebase Studio</a> have rules files useful for providing critical context to LLMs.
+## Archivos de Reglas
+Varios editores, como <a href="https://studio.firebase.google.com?utm_source=adev&utm_medium=website&utm_campaign=BUILD_WITH_AI_ANGULAR&utm_term=angular_devrel&utm_content=build_with_ai_angular_firebase_studio">Firebase Studio</a> tienen archivos de reglas útiles para proporcionar contexto crítico a los LLMs.
 
-| Environment/IDE | Rules File                                                      | Installation Instructions                                                                                              |
+| Entorno/IDE | Archivo de Reglas                                                      | Instrucciones de Instalación                                                                                              |
 |:----------------|:----------------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------|
-| Firebase Studio | <a download href="/assets/context/airules.md" target="_blank">airules.md</a>    | <a href="https://firebase.google.com/docs/studio/set-up-gemini#custom-instructions">Configure `airules.md`</a>         |
-| Copilot powered IDEs | <a download="copilot-instructions.md" href="/assets/context/guidelines.md" target="_blank">copilot-instructions.md</a>  | <a href="https://code.visualstudio.com/docs/copilot/copilot-customization#_custom-instructions" target="_blank">Configure `.github/copilot-instructions.md`</a> |
-| Cursor          | <a download href="/assets/context/angular-20.mdc" target="_blank">cursor.md</a> | <a href="https://docs.cursor.com/context/rules" target="_blank">Configure `cursorrules.md`</a>                         |
-| JetBrains IDEs  | <a download href="/assets/context/guidelines.md" target="_blank">guidelines.md</a>  | <a href="https://www.jetbrains.com/help/junie/customize-guidelines.html" target="_blank">Configure `guidelines.md`</a> |
-| VS Code | <a download=".instructions.md" href="/assets/context/guidelines.md" target="_blank">.instructions.md</a>  | <a href="https://code.visualstudio.com/docs/copilot/copilot-customization#_custom-instructions" target="_blank">Configure `.instructions.md`</a> |
-| Windsurf | <a download href="/assets/context/guidelines.md" target="_blank">guidelines.md</a>  | <a href="https://docs.windsurf.com/windsurf/cascade/memories#rules" target="_blank">Configure `guidelines.md`</a> |
+| Firebase Studio | <a download href="/assets/context/airules.md" target="_blank">airules.md</a>    | <a href="https://firebase.google.com/docs/studio/set-up-gemini#custom-instructions">Configurar `airules.md`</a>         |
+| IDEs potenciados por Copilot | <a download="copilot-instructions.md" href="/assets/context/guidelines.md" target="_blank">copilot-instructions.md</a>  | <a href="https://code.visualstudio.com/docs/copilot/copilot-customization#_custom-instructions" target="_blank">Configurar `.github/copilot-instructions.md`</a> |
+| Cursor          | <a download href="/assets/context/angular-20.mdc" target="_blank">cursor.md</a> | <a href="https://docs.cursor.com/context/rules" target="_blank">Configurar `cursorrules.md`</a>                         |
+| IDEs de JetBrains  | <a download href="/assets/context/guidelines.md" target="_blank">guidelines.md</a>  | <a href="https://www.jetbrains.com/help/junie/customize-guidelines.html" target="_blank">Configurar `guidelines.md`</a> |
+| VS Code | <a download=".instructions.md" href="/assets/context/guidelines.md" target="_blank">.instructions.md</a>  | <a href="https://code.visualstudio.com/docs/copilot/copilot-customization#_custom-instructions" target="_blank">Configurar `.instructions.md`</a> |
+| Windsurf | <a download href="/assets/context/guidelines.md" target="_blank">guidelines.md</a>  | <a href="https://docs.windsurf.com/windsurf/cascade/memories#rules" target="_blank">Configurar `guidelines.md`</a> |
 
-## Angular CLI MCP Server setup
-The Angular CLI includes an experimental [Model Context Protocol (MCP) server](https://modelcontextprotocol.io/) that allows AI assistants in your development environment to interact with the Angular CLI.
+## Configuración del Servidor MCP de Angular CLI
+Angular CLI incluye un [servidor de Model Context Protocol (MCP)](https://modelcontextprotocol.io/) experimental que permite a los asistentes de IA en tu entorno de desarrollo interactuar con Angular CLI.
 
-[**Learn how to set up the Angular CLI MCP Server**](/ai/mcp)
+[**Aprende cómo configurar el Servidor MCP de Angular CLI**](/ai/mcp)
 
-## Providing Context with `llms.txt`
-`llms.txt` is a proposed standard for websites designed to help LLMs better understand and process their content. The Angular team has developed two versions of this file to help LLMs and tools that use LLMs for code generation to create better modern Angular code.
+## Proporcionando Contexto con `llms.txt`
+`llms.txt` es un estándar propuesto para sitios web diseñado para ayudar a los LLMs a entender y procesar mejor su contenido. El equipo de Angular ha desarrollado dos versiones de este archivo para ayudar a los LLMs y herramientas que usan LLMs para generación de código a crear mejor código Angular moderno.
 
 
-* <a href="/llms.txt" target="_blank">llms.txt</a> - an index file providing links to key files and resources. 
-* <a href="/context/llm-files/llms-full.txt" target="_blank">llms-full.txt</a> - a more robust compiled set of resources describing how Angular works and how to build Angular applications.
+* <a href="/llms.txt" target="_blank">llms.txt</a> - un archivo índice que proporciona enlaces a archivos y recursos clave.
+* <a href="/context/llm-files/llms-full.txt" target="_blank">llms-full.txt</a> - un conjunto compilado más robusto de recursos que describen cómo funciona Angular y cómo construir aplicaciones Angular.
 
-Be sure [to check out the overview page](/ai) for more information on how to integrate AI into your Angular applications.
+Asegúrate de [consultar la página de visión general](/ai) para más información sobre cómo integrar IA en tus aplicaciones Angular.
 
 ## Web Codegen Scorer
-The Angular team developed and open-sourced the [Web Codegen Scorer](https://github.com/angular/web-codegen-scorer), a tool to evaluate and score the quality of AI generated web code. You can use this tool to make evidence-based decisions relating to AI-generated code, such as fine-tuning prompts to improve the accuracy of LLM-generated code for Angular. These prompts can be included as system instructions for your AI tooling or as context with your prompt. You can also use this tool to compare the quality of code produced by different models and monitor quality over time as models and agents evolve.
+El equipo de Angular desarrolló y publicó como código abierto el [Web Codegen Scorer](https://github.com/angular/web-codegen-scorer), una herramienta para evaluar y puntuar la calidad del código web generado por IA. Puedes usar esta herramienta para tomar decisiones basadas en evidencia relacionadas con código generado por IA, como ajustar prompts para mejorar la precisión del código generado por LLM para Angular. Estos prompts pueden incluirse como instrucciones del sistema para tus herramientas de IA o como contexto con tu prompt. También puedes usar esta herramienta para comparar la calidad del código producido por diferentes modelos y monitorear la calidad a lo largo del tiempo a medida que los modelos y agentes evolucionan.
 

--- a/adev-es/src/content/ai/mcp-server-setup.en.md
+++ b/adev-es/src/content/ai/mcp-server-setup.en.md
@@ -1,0 +1,141 @@
+# Angular CLI MCP Server setup
+
+The Angular CLI includes an experimental [Model Context Protocol (MCP) server](https://modelcontextprotocol.io/) enabling AI assistants in your development environment to interact with the Angular CLI. We've included support for CLI powered code generation, adding packages, and more.
+
+## Available Tools
+
+The Angular CLI MCP server provides several tools to assist you in your development workflow. By default, the following tools are enabled:
+
+| Name                   | Description                                                                                                                                                                                        | `local-only` | `read-only` |
+| :--------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :----------: | :---------: |
+| `get_best_practices`   | Retrieves the Angular Best Practices Guide. This guide is essential for ensuring that all code adheres to modern standards, including standalone components, typed forms, and modern control flow. |      ✅      |      ✅     |
+| `list_projects`        | Lists the names of all applications and libraries defined within an Angular workspace. It reads the `angular.json` configuration file to identify the projects.                                    |      ✅      |      ✅     |
+| `search_documentation` | Searches the official Angular documentation at https://angular.dev. This tool should be used to answer any questions about Angular, such as for APIs, tutorials, and best practices.               |      ❌      |      ✅     |
+
+## Get Started
+
+To get started, run the following command in your terminal:
+
+```bash
+ng mcp
+```
+
+When run from an interactive terminal, this command displays instructions on how to configure a host environment to use the MCP server. The following sections provide example configurations for several popular editors and tools.
+
+### Cursor
+
+Create a file named `.cursor/mcp.json` in your project's root and add the following configuration. You can also configure it globally in `~/.cursor/mcp.json`.
+
+```json
+{
+  "mcpServers": {
+    "angular-cli": {
+      "command": "npx",
+      "args": ["-y", "@angular/cli", "mcp"]
+    }
+  }
+}
+```
+
+### Firebase Studio
+
+Create a file named `.idx/mcp.json` in your project's root and add the following configuration:
+
+```json
+{
+  "mcpServers": {
+    "angular-cli": {
+      "command": "npx",
+      "args": ["-y", "@angular/cli", "mcp"]
+    }
+  }
+}
+```
+
+### Gemini CLI
+
+Create a file named `.gemini/settings.json` in your project's root and add the following configuration:
+
+```json
+{
+  "mcpServers": {
+    "angular-cli": {
+      "command": "npx",
+      "args": ["-y", "@angular/cli", "mcp"]
+    }
+  }
+}
+```
+
+### JetBrains IDEs
+
+In JetBrains IDEs (like IntelliJ IDEA or WebStorm), after installing the JetBrains AI Assistant plugin, go to `Settings | Tools | AI Assistant | Model Context Protocol (MCP)`. Add a new server and select `As JSON`. Paste the following configuration, which does not use a top-level property for the server list.
+
+```json
+{
+  "name": "Angular CLI",
+  "command": "npx",
+  "args": [
+    "-y",
+    "@angular/cli",
+    "mcp"
+  ]
+}
+```
+
+### VS Code
+
+In your project's root, create a file named `.vscode/mcp.json` and add the following configuration. Note the use of the `servers` property.
+
+```json
+{
+  "servers": {
+    "angular-cli": {
+      "command": "npx",
+      "args": ["-y", "@angular/cli", "mcp"]
+    }
+  }
+}
+```
+
+### Other IDEs
+
+For other IDEs, check your IDE's documentation for the proper location of the MCP configuration file (often `mcp.json`). The configuration should contain the following snippet.
+
+```json
+{
+  "mcpServers": {
+    "angular-cli": {
+      "command": "npx",
+      "args": ["-y", "@angular/cli", "mcp"]
+    }
+  }
+}
+```
+
+## Command Options
+
+The `mcp` command can be configured with the following options passed as arguments in your IDE's MCP configuration:
+
+| Option         | Type      | Description                                                                                                | Default |
+| :------------- | :-------- | :--------------------------------------------------------------------------------------------------------- | :------ |
+| `--read-only`  | `boolean` | Only register tools that do not make changes to the project. Your editor or coding agent may still perform edits. | `false` |
+| `--local-only` | `boolean` | Only register tools that do not require an internet connection. Your editor or coding agent may still send data over the network. | `false` |
+
+
+For example, to run the server in read-only mode in VS Code, you would update your `mcp.json` like this:
+
+```json
+{
+  "servers": {
+    "angular-cli": {
+      "command": "npx",
+      "args": ["-y", "@angular/cli", "mcp", "--read-only"]
+    }
+  }
+}
+```
+
+## Feedback and New Ideas
+
+The Angular team welcomes your feedback on the existing MCP capabilities and any ideas you have for new tools or features. Please share your thoughts by opening an issue on the [angular/angular GitHub repository](https://github.com/angular/angular/issues).

--- a/adev-es/src/content/ai/mcp-server-setup.md
+++ b/adev-es/src/content/ai/mcp-server-setup.md
@@ -1,30 +1,30 @@
-# Angular CLI MCP Server setup
+# Configuración del Servidor MCP de Angular CLI
 
-The Angular CLI includes an experimental [Model Context Protocol (MCP) server](https://modelcontextprotocol.io/) enabling AI assistants in your development environment to interact with the Angular CLI. We've included support for CLI powered code generation, adding packages, and more.
+Angular CLI incluye un [servidor de Model Context Protocol (MCP)](https://modelcontextprotocol.io/) experimental que permite a los asistentes de IA en tu entorno de desarrollo interactuar con Angular CLI. Hemos incluido soporte para generación de código potenciado por CLI, agregar paquetes y más.
 
-## Available Tools
+## Herramientas Disponibles
 
-The Angular CLI MCP server provides several tools to assist you in your development workflow. By default, the following tools are enabled:
+El servidor MCP de Angular CLI proporciona varias herramientas para asistirte en tu flujo de trabajo de desarrollo. Por defecto, las siguientes herramientas están habilitadas:
 
-| Name                   | Description                                                                                                                                                                                        | `local-only` | `read-only` |
+| Nombre                 | Descripción                                                                                                                                                                                        | `local-only` | `read-only` |
 | :--------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :----------: | :---------: |
-| `get_best_practices`   | Retrieves the Angular Best Practices Guide. This guide is essential for ensuring that all code adheres to modern standards, including standalone components, typed forms, and modern control flow. |      ✅      |      ✅     |
-| `list_projects`        | Lists the names of all applications and libraries defined within an Angular workspace. It reads the `angular.json` configuration file to identify the projects.                                    |      ✅      |      ✅     |
-| `search_documentation` | Searches the official Angular documentation at https://angular.dev. This tool should be used to answer any questions about Angular, such as for APIs, tutorials, and best practices.               |      ❌      |      ✅     |
+| `get_best_practices`   | Recupera la Guía de Mejores Prácticas de Angular. Esta guía es esencial para asegurar que todo el código se adhiera a los estándares modernos, incluyendo componentes standalone, formularios tipados y flujo de control moderno. |      ✅      |      ✅     |
+| `list_projects`        | Lista los nombres de todas las aplicaciones y bibliotecas definidas dentro de un espacio de trabajo de Angular. Lee el archivo de configuración `angular.json` para identificar los proyectos.                                    |      ✅      |      ✅     |
+| `search_documentation` | Busca en la documentación oficial de Angular en https://angular.dev. Esta herramienta debe usarse para responder cualquier pregunta sobre Angular, como para APIs, tutoriales y mejores prácticas.               |      ❌      |      ✅     |
 
-## Get Started
+## Primeros Pasos
 
-To get started, run the following command in your terminal:
+Para comenzar, ejecuta el siguiente comando en tu terminal:
 
 ```bash
 ng mcp
 ```
 
-When run from an interactive terminal, this command displays instructions on how to configure a host environment to use the MCP server. The following sections provide example configurations for several popular editors and tools.
+Cuando se ejecuta desde una terminal interactiva, este comando muestra instrucciones sobre cómo configurar un entorno host para usar el servidor MCP. Las siguientes secciones proporcionan configuraciones de ejemplo para varios editores y herramientas populares.
 
 ### Cursor
 
-Create a file named `.cursor/mcp.json` in your project's root and add the following configuration. You can also configure it globally in `~/.cursor/mcp.json`.
+Crea un archivo llamado `.cursor/mcp.json` en la raíz de tu proyecto y agrega la siguiente configuración. También puedes configurarlo globalmente en `~/.cursor/mcp.json`.
 
 ```json
 {
@@ -39,7 +39,7 @@ Create a file named `.cursor/mcp.json` in your project's root and add the follow
 
 ### Firebase Studio
 
-Create a file named `.idx/mcp.json` in your project's root and add the following configuration:
+Crea un archivo llamado `.idx/mcp.json` en la raíz de tu proyecto y agrega la siguiente configuración:
 
 ```json
 {
@@ -54,7 +54,7 @@ Create a file named `.idx/mcp.json` in your project's root and add the following
 
 ### Gemini CLI
 
-Create a file named `.gemini/settings.json` in your project's root and add the following configuration:
+Crea un archivo llamado `.gemini/settings.json` en la raíz de tu proyecto y agrega la siguiente configuración:
 
 ```json
 {
@@ -67,9 +67,9 @@ Create a file named `.gemini/settings.json` in your project's root and add the f
 }
 ```
 
-### JetBrains IDEs
+### IDEs de JetBrains
 
-In JetBrains IDEs (like IntelliJ IDEA or WebStorm), after installing the JetBrains AI Assistant plugin, go to `Settings | Tools | AI Assistant | Model Context Protocol (MCP)`. Add a new server and select `As JSON`. Paste the following configuration, which does not use a top-level property for the server list.
+En los IDEs de JetBrains (como IntelliJ IDEA o WebStorm), después de instalar el plugin JetBrains AI Assistant, ve a `Settings | Tools | AI Assistant | Model Context Protocol (MCP)`. Agrega un nuevo servidor y selecciona `As JSON`. Pega la siguiente configuración, que no usa una propiedad de nivel superior para la lista de servidores.
 
 ```json
 {
@@ -85,7 +85,7 @@ In JetBrains IDEs (like IntelliJ IDEA or WebStorm), after installing the JetBrai
 
 ### VS Code
 
-In your project's root, create a file named `.vscode/mcp.json` and add the following configuration. Note the use of the `servers` property.
+En la raíz de tu proyecto, crea un archivo llamado `.vscode/mcp.json` y agrega la siguiente configuración. Nota el uso de la propiedad `servers`.
 
 ```json
 {
@@ -98,9 +98,9 @@ In your project's root, create a file named `.vscode/mcp.json` and add the follo
 }
 ```
 
-### Other IDEs
+### Otros IDEs
 
-For other IDEs, check your IDE's documentation for the proper location of the MCP configuration file (often `mcp.json`). The configuration should contain the following snippet.
+Para otros IDEs, consulta la documentación de tu IDE para la ubicación adecuada del archivo de configuración MCP (a menudo `mcp.json`). La configuración debe contener el siguiente fragmento.
 
 ```json
 {
@@ -113,17 +113,17 @@ For other IDEs, check your IDE's documentation for the proper location of the MC
 }
 ```
 
-## Command Options
+## Opciones de Comando
 
-The `mcp` command can be configured with the following options passed as arguments in your IDE's MCP configuration:
+El comando `mcp` puede configurarse con las siguientes opciones pasadas como argumentos en la configuración MCP de tu IDE:
 
-| Option         | Type      | Description                                                                                                | Default |
+| Opción         | Tipo      | Descripción                                                                                                | Predeterminado |
 | :------------- | :-------- | :--------------------------------------------------------------------------------------------------------- | :------ |
-| `--read-only`  | `boolean` | Only register tools that do not make changes to the project. Your editor or coding agent may still perform edits. | `false` |
-| `--local-only` | `boolean` | Only register tools that do not require an internet connection. Your editor or coding agent may still send data over the network. | `false` |
+| `--read-only`  | `boolean` | Solo registra herramientas que no realizan cambios en el proyecto. Tu editor o agente de codificación aún puede realizar ediciones. | `false` |
+| `--local-only` | `boolean` | Solo registra herramientas que no requieren una conexión a internet. Tu editor o agente de codificación aún puede enviar datos a través de la red. | `false` |
 
 
-For example, to run the server in read-only mode in VS Code, you would update your `mcp.json` like this:
+Por ejemplo, para ejecutar el servidor en modo de solo lectura en VS Code, actualizarías tu `mcp.json` así:
 
 ```json
 {
@@ -136,6 +136,6 @@ For example, to run the server in read-only mode in VS Code, you would update yo
 }
 ```
 
-## Feedback and New Ideas
+## Comentarios y Nuevas Ideas
 
-The Angular team welcomes your feedback on the existing MCP capabilities and any ideas you have for new tools or features. Please share your thoughts by opening an issue on the [angular/angular GitHub repository](https://github.com/angular/angular/issues).
+El equipo de Angular agradece tus comentarios sobre las capacidades MCP existentes y cualquier idea que tengas para nuevas herramientas o características. Por favor comparte tus pensamientos abriendo un issue en el [repositorio de GitHub angular/angular](https://github.com/angular/angular/issues).

--- a/adev-es/src/content/ai/overview.en.md
+++ b/adev-es/src/content/ai/overview.en.md
@@ -1,0 +1,101 @@
+<!-- TODO: need an Angular + AI logo -->
+<docs-decorative-header title="Build with AI" imgSrc="adev/src/assets/images/what_is_angular.svg"> <!-- markdownlint-disable-line -->
+Build AI-powered apps. Develop faster with AI.
+</docs-decorative-header>
+
+HELPFUL: Looking to get started with building in your favorite AI powered IDE? <br>Check out our [prompt rules and best practices](/ai/develop-with-ai).
+
+Generative AI (GenAI) with large language models (LLMs) enables the creation of sophisticated and engaging application experiences, including personalized content, intelligent recommendations, media generation and comprehension, information summarization, and dynamic functionality.
+
+Developing features like these would have previously required deep domain expertise and significant engineering effort. However, new products and SDKs are lowering the barrier to entry. Angular is well-suited for integrating AI into your web application as a result of:
+
+* Angular's robust templating APIs enable the creation of dynamic, cleanly composed UIs made from generated content
+* Strong, signal-based architecture designed to dynamically manage data and state
+* Angular integrates seamlessly with AI SDKs and APIs
+
+This guide demonstrates how you can use [Genkit](/ai#build-ai-powered-applications-with-genkit-and-angular), [Firebase AI Logic](/ai#build-ai-powered-applications-with-firebase-ai-logic-and-angular), and the [Gemini API](/ai#build-ai-powered-applications-with-gemini-api-and-angular) to infuse your Angular apps with AI today. This guide will jumpstart your AI-powered web app development journey by explaining how to begin integrating AI into Angular apps. This guide also shares resources, such as starter kits, example code, and recipes for common workflows, you can use to get up to speed quickly.
+
+To get started, you should have a basic understanding of Angular. New to Angular? Try our [essentials guide](/essentials) or our [getting started tutorials](/tutorials).
+
+NOTE: While this page features integrations and examples with Google AI products, tools like Genkit are model agnostic and allow you to choose your own model. In many cases, the examples and code samples are applicable to other third-party solutions.
+
+## Getting Started
+Building AI-powered applications is a new and rapidly developing field. It can be challenging to decide where to start and which technologies to choose. The following section provides three options to choose from:
+
+1. *Genkit* gives you the choice of [supported model and interface with a unified API](https://genkit.dev) for building full-stack applications. Ideal for applications requiring sophisticated back-end AI logic, such as personalized recommendations.
+
+1. *Firebase AI Logic* provides a secure client-side API for Google's models to build client-side only applications or mobile apps. Best for interactive AI features directly in the browser, such as real-time text analysis or basic chatbots.
+
+1. *Gemini API* enables you to build an application that uses the methods and functionality exposed through the API surface directly, best for full-stack applications. Suitable for applications needing direct control over AI models, like custom image generation or deep data processing.
+
+### Build AI-powered applications with Genkit and Angular
+[Genkit](https://genkit.dev) is an open-source toolkit designed to help you build AI-powered features in web and mobile apps. It offers a unified interface for integrating AI models from Google, OpenAI, Anthropic, Ollama, and more, so you can explore and choose the best models for your needs. As a server-side solution, your web apps need a supported server environment, such as a node-based server in order to integrate with Genkit. Building a full-stack app using Angular SSR gives you the starting server-side code, for example. 
+
+Here are examples of how to build with Genkit and Angular:
+
+* [Agentic Apps with Genkit and Angular starter-kit](https://github.com/angular/examples/tree/main/genkit-angular-starter-kit)— New to building with AI? Start here with a basic app that features an agentic workflow. Perfect place to start for your first AI building experience.
+
+* [Use Genkit in an Angular app](https://genkit.dev/docs/angular/)— Build a basic application that uses Genkit Flows, Angular and Gemini 2.5 Flash. This step-by-step walkthrough guides you through creating a full-stack Angular application with AI features.
+
+* [Dynamic Story Generator app](https://github.com/angular/examples/tree/main/genkit-angular-story-generator)— Learn to build an agentic Angular app powered by Genkit, Gemini and Imagen 3 to dynamically generate a story based on user interaction featuring beautiful image panels to accompany the events that take place. Start here if you'd like to experiment with a more advanced use-case.
+
+  This example also has an in-depth video walkthrough of the functionality:
+    * [Watch "Building Agentic Apps with Angular and Genkit live!"](https://youtube.com/live/mx7yZoIa2n4?feature=share)
+    * [Watch "Building Agentic Apps with Angular and Genkit live! PT 2"](https://youtube.com/live/YR6LN5_o3B0?feature=share)
+
+* [Building Agentic apps with Firebase and Google Cloud (Barista Example)](https://developers.google.com/solutions/learn/agentic-barista) - Learn how to build an agentic coffee ordering app with Firebase and Google Cloud. This example uses both Firebase AI Logic and Genkit.
+
+### Build AI-powered applications with Firebase AI Logic and Angular
+[Firebase AI Logic](https://firebase.google.com/products/vertex-ai-in-firebase) provides a secure way to interact with Vertex AI Gemini API or Imagen API directly from your web and mobile apps. This is compelling for Angular developers since apps can be either full-stack or client-side only. If you are developing a client-side only application, Firebase AI Logic is a good fit for incorporating AI into your web apps.
+
+Here is an example of how to build with Firebase AI Logic and Angular:
+* [Firebase AI Logic x Angular Starter Kit](https://github.com/angular/examples/tree/main/vertex-ai-firebase-angular-example) - Use this starter-kit to build an e-commerce application with a chat agent that can perform tasks. Start here if you do not have experience building with Firebase AI Logic and Angular.
+
+  This example includes an [in-depth video walkthrough explaining the functionality and demonstrates how to add new features](https://youtube.com/live/4vfDz2al_BI).
+
+### Build AI-powered applications with Gemini API and Angular
+The [Gemini API](https://ai.google.dev/gemini-api/docs) provides access to state-of-the-art models from Google that support audio, images, video, and text input. These models that are optimized for specific use cases, [learn more on the Gemini API documentation site](https://ai.google.dev/gemini-api/docs/models).
+
+* [AI Text Editor Angular app template](https://github.com/FirebaseExtended/firebase-framework-tools/tree/main/starters/angular/ai-text-editor) - Use this template to start with a fully functioning text editor with AI-powered features like refining text, expanding text and formalizing text. This is a good starting point to gain experience with calling the Gemini API via HTTP.
+
+* [AI Chatbot app template](https://github.com/FirebaseExtended/firebase-framework-tools/tree/main/starters/angular/ai-chatbot) - This template starts with a chatbot user interface that communicates with the Gemini API via HTTP. 
+
+## Best Practices
+### Connecting to model providers and keeping your API Credentials Secure
+When connecting to model providers, it is important to keep your API secrets safe. *Never put your API key in a file that ships to the client, such as `environments.ts`*.
+
+Your application's architecture determines which AI APIs and tools to choose. Specifically, choose based on whether or not your application is client-side or server-side. Tools such as Firebase AI Logic provide a secure connection to the model APIs for client-side code. If you want to use a different API than Firebase AI Logic or prefer to use a different model provider, consider creating a proxy-server or even [Cloud Functions for Firebase](https://firebase.google.com/docs/functions) to serve as a proxy and not expose your API keys.
+
+For an example of connecting using a client-side app, see the code:  [Firebase AI Logic Angular example repository](https://github.com/angular/examples/tree/main/vertex-ai-firebase-angular-example).
+
+For server-side connections to model APIs that require API keys, prefer using a secrets manager or environment variable, not `environments.ts`. You should follow standard best practices for securing API keys and credentials. Firebase now provides a new secrets manager with the latest updates from Firebase App Hosting. To learn more, [check out the official documentation](https://firebase.google.com/docs/app-hosting/configure).
+
+For a server-side connection example in a full-stack application, see the code: [Angular AI Example (Genkit and Angular Story Generator) repository](https://github.com/angular/examples/tree/main/genkit-angular-story-generator).
+
+### Use Tool Calling to enhance apps
+If you want to build agentic workflows, where agents are able to act and use tools to solve problems based on prompts use "tool calling". Tool calling, also known as function calling, is a way to provide LLMs the ability to make requests back to the application that called it. As a developer, you define which tools are available and you are in control of how or when the tools are called.
+
+Tool calling further enhances your web apps by expanding your AI integration further than a question and answer style chat bot. In fact, you can empower your model to request function calls using the function calling API of your model provider. The available tools can be used to perform more complex actions within the context of your application. 
+
+In the [e-commerce example](https://github.com/angular/examples/blob/main/vertex-ai-firebase-angular-example/src/app/ai.service.ts#L88) of the [Angular examples repository](https://github.com/angular/examples), the LLM requests to make calls to functions for inventory in order to gain the necessary context to perform more complex tasks such as calculating how much a group of items in the store will cost. The scope of the available API is up to you as a developer just as is whether or not to call a function requested by the LLM. You remain in control of the flow of execution. You can expose specific functions of a service for example but not all functions of that service.
+
+### Handling non-deterministic responses
+Because models can return non-deterministic results, your applications should be designed with that in mind. Here are a few strategies that you can use in your application implementation:
+* Adjust prompts and model parameters (such as [temperature](https://ai.google.dev/gemini-api/docs/prompting-strategies)) for more or less deterministic responses. You can [find out more in the prompting strategies section](https://ai.google.dev/gemini-api/docs/prompting-strategies) of [ai.google.dev](https://ai.google.dev/).
+* Use the "human in the loop" strategy where a human verifies outputs before proceeding in a workflow. Build your application workflows to allow operators (humans or other models) to verify outputs and confirm key decisions.
+* Employ tool (or function) calling and schema constraints to guide and restrict model responses to predefined formats, increasing response predictability.
+
+Even considering these strategies and techniques, sensible fallbacks should be incorporated in your application design. Follow existing standards of application resiliency. For example, it is not acceptable for an application to crash if a resource or API is not available. In that scenario, an error message is displayed to the user and, if applicable, options for next steps are also displayed. Building AI-powered applications requires the same consideration. Confirm that the response is aligned with the expected output and provide a "safe landing" in case it is not aligned by way of [graceful degradation](https://developer.mozilla.org/en-US/docs/Glossary/Graceful_degradation). This also applies to API outages for LLM providers.
+
+Consider this example: The LLM provider is not responding. A potential strategy to handle the outage is:
+* Save the response from the user to use in a retry scenario (now or at a later time)
+* Alert the user to the outage with an appropriate message that doesn't reveal sensitive information
+* Resume the conversation at a later time once the services are available again.
+
+## Next steps
+
+To learn about LLM prompts and AI IDE setup, see the following guides:
+
+<docs-pill-row>
+  <docs-pill href="ai/develop-with-ai" title="LLM prompts and IDE setup"/>
+</docs-pill-row>

--- a/adev-es/src/content/ai/overview.md
+++ b/adev-es/src/content/ai/overview.md
@@ -1,101 +1,101 @@
 <!-- TODO: need an Angular + AI logo -->
-<docs-decorative-header title="Build with AI" imgSrc="adev/src/assets/images/what_is_angular.svg"> <!-- markdownlint-disable-line -->
-Build AI-powered apps. Develop faster with AI.
+<docs-decorative-header title="Construye con IA" imgSrc="adev/src/assets/images/what_is_angular.svg"> <!-- markdownlint-disable-line -->
+Construye aplicaciones potenciadas por IA. Desarrolla más rápido con IA.
 </docs-decorative-header>
 
-HELPFUL: Looking to get started with building in your favorite AI powered IDE? <br>Check out our [prompt rules and best practices](/ai/develop-with-ai).
+ÚTIL: ¿Buscas comenzar a construir en tu IDE potenciado por IA favorito? <br>Consulta nuestras [reglas de prompts y mejores prácticas](/ai/develop-with-ai).
 
-Generative AI (GenAI) with large language models (LLMs) enables the creation of sophisticated and engaging application experiences, including personalized content, intelligent recommendations, media generation and comprehension, information summarization, and dynamic functionality.
+La IA generativa (GenAI) con modelos de lenguaje grandes (LLMs) permite la creación de experiencias de aplicación sofisticadas y atractivas, incluyendo contenido personalizado, recomendaciones inteligentes, generación y comprensión de medios, resúmenes de información y funcionalidad dinámica.
 
-Developing features like these would have previously required deep domain expertise and significant engineering effort. However, new products and SDKs are lowering the barrier to entry. Angular is well-suited for integrating AI into your web application as a result of:
+Desarrollar características como estas habría requerido previamente experiencia profunda en el dominio y un esfuerzo de ingeniería significativo. Sin embargo, nuevos productos y SDKs están bajando la barrera de entrada. Angular es ideal para integrar IA en tu aplicación web como resultado de:
 
-* Angular's robust templating APIs enable the creation of dynamic, cleanly composed UIs made from generated content
-* Strong, signal-based architecture designed to dynamically manage data and state
-* Angular integrates seamlessly with AI SDKs and APIs
+* Las APIs de plantillas robustas de Angular permiten la creación de interfaces de usuario dinámicas, claramente compuestas y hechas a partir de contenido generado
+* Arquitectura sólida basada en signals diseñada para gestionar dinámicamente datos y estado
+* Angular se integra perfectamente con SDKs y APIs de IA
 
-This guide demonstrates how you can use [Genkit](/ai#build-ai-powered-applications-with-genkit-and-angular), [Firebase AI Logic](/ai#build-ai-powered-applications-with-firebase-ai-logic-and-angular), and the [Gemini API](/ai#build-ai-powered-applications-with-gemini-api-and-angular) to infuse your Angular apps with AI today. This guide will jumpstart your AI-powered web app development journey by explaining how to begin integrating AI into Angular apps. This guide also shares resources, such as starter kits, example code, and recipes for common workflows, you can use to get up to speed quickly.
+Esta guía demuestra cómo puedes usar [Genkit](/ai#build-ai-powered-applications-with-genkit-and-angular), [Firebase AI Logic](/ai#build-ai-powered-applications-with-firebase-ai-logic-and-angular) y la [Gemini API](/ai#build-ai-powered-applications-with-gemini-api-and-angular) para infundir IA en tus aplicaciones Angular hoy. Esta guía impulsará tu viaje de desarrollo de aplicaciones web potenciadas por IA explicando cómo comenzar a integrar IA en aplicaciones Angular. Esta guía también comparte recursos, como kits de inicio, código de ejemplo y recetas para flujos de trabajo comunes, que puedes usar para ponerte al día rápidamente.
 
-To get started, you should have a basic understanding of Angular. New to Angular? Try our [essentials guide](/essentials) or our [getting started tutorials](/tutorials).
+Para comenzar, deberías tener un entendimiento básico de Angular. ¿Nuevo en Angular? Prueba nuestra [guía de elementos esenciales](/essentials) o nuestros [tutoriales de primeros pasos](/tutorials).
 
-NOTE: While this page features integrations and examples with Google AI products, tools like Genkit are model agnostic and allow you to choose your own model. In many cases, the examples and code samples are applicable to other third-party solutions.
+NOTA: Aunque esta página presenta integraciones y ejemplos con productos de IA de Google, herramientas como Genkit son agnósticas de modelo y te permiten elegir tu propio modelo. En muchos casos, los ejemplos y muestras de código son aplicables a otras soluciones de terceros.
 
-## Getting Started
-Building AI-powered applications is a new and rapidly developing field. It can be challenging to decide where to start and which technologies to choose. The following section provides three options to choose from:
+## Primeros Pasos
+Construir aplicaciones potenciadas por IA es un campo nuevo y en rápido desarrollo. Puede ser desafiante decidir dónde empezar y qué tecnologías elegir. La siguiente sección proporciona tres opciones para elegir:
 
-1. *Genkit* gives you the choice of [supported model and interface with a unified API](https://genkit.dev) for building full-stack applications. Ideal for applications requiring sophisticated back-end AI logic, such as personalized recommendations.
+1. *Genkit* te da la opción de [modelo soportado e interfaz con una API unificada](https://genkit.dev) para construir aplicaciones full-stack. Ideal para aplicaciones que requieren lógica de IA sofisticada en el backend, como recomendaciones personalizadas.
 
-1. *Firebase AI Logic* provides a secure client-side API for Google's models to build client-side only applications or mobile apps. Best for interactive AI features directly in the browser, such as real-time text analysis or basic chatbots.
+1. *Firebase AI Logic* proporciona una API segura del lado del cliente para los modelos de Google para construir aplicaciones de solo lado del cliente o aplicaciones móviles. Mejor para características de IA interactivas directamente en el navegador, como análisis de texto en tiempo real o chatbots básicos.
 
-1. *Gemini API* enables you to build an application that uses the methods and functionality exposed through the API surface directly, best for full-stack applications. Suitable for applications needing direct control over AI models, like custom image generation or deep data processing.
+1. *Gemini API* te permite construir una aplicación que use los métodos y funcionalidades expuestos a través de la superficie de la API directamente, mejor para aplicaciones full-stack. Adecuado para aplicaciones que necesitan control directo sobre modelos de IA, como generación de imágenes personalizadas o procesamiento profundo de datos.
 
-### Build AI-powered applications with Genkit and Angular
-[Genkit](https://genkit.dev) is an open-source toolkit designed to help you build AI-powered features in web and mobile apps. It offers a unified interface for integrating AI models from Google, OpenAI, Anthropic, Ollama, and more, so you can explore and choose the best models for your needs. As a server-side solution, your web apps need a supported server environment, such as a node-based server in order to integrate with Genkit. Building a full-stack app using Angular SSR gives you the starting server-side code, for example. 
+### Construye aplicaciones potenciadas por IA con Genkit y Angular
+[Genkit](https://genkit.dev) es un toolkit de código abierto diseñado para ayudarte a construir características potenciadas por IA en aplicaciones web y móviles. Ofrece una interfaz unificada para integrar modelos de IA de Google, OpenAI, Anthropic, Ollama y más, para que puedas explorar y elegir los mejores modelos para tus necesidades. Como solución del lado del servidor, tus aplicaciones web necesitan un entorno de servidor soportado, como un servidor basado en node para integrarse con Genkit. Construir una aplicación full-stack usando Angular SSR te da el código inicial del lado del servidor, por ejemplo.
 
-Here are examples of how to build with Genkit and Angular:
+Aquí hay ejemplos de cómo construir con Genkit y Angular:
 
-* [Agentic Apps with Genkit and Angular starter-kit](https://github.com/angular/examples/tree/main/genkit-angular-starter-kit)— New to building with AI? Start here with a basic app that features an agentic workflow. Perfect place to start for your first AI building experience.
+* [Aplicaciones Agénticas con Genkit y Angular starter-kit](https://github.com/angular/examples/tree/main/genkit-angular-starter-kit)— ¿Nuevo construyendo con IA? Comienza aquí con una aplicación básica que presenta un flujo de trabajo agéntico. Lugar perfecto para comenzar tu primera experiencia de construcción con IA.
 
-* [Use Genkit in an Angular app](https://genkit.dev/docs/angular/)— Build a basic application that uses Genkit Flows, Angular and Gemini 2.5 Flash. This step-by-step walkthrough guides you through creating a full-stack Angular application with AI features.
+* [Usar Genkit en una aplicación Angular](https://genkit.dev/docs/angular/)— Construye una aplicación básica que usa Genkit Flows, Angular y Gemini 2.5 Flash. Este tutorial paso a paso te guía a través de la creación de una aplicación Angular full-stack con características de IA.
 
-* [Dynamic Story Generator app](https://github.com/angular/examples/tree/main/genkit-angular-story-generator)— Learn to build an agentic Angular app powered by Genkit, Gemini and Imagen 3 to dynamically generate a story based on user interaction featuring beautiful image panels to accompany the events that take place. Start here if you'd like to experiment with a more advanced use-case.
+* [Aplicación de Generador de Historias Dinámico](https://github.com/angular/examples/tree/main/genkit-angular-story-generator)— Aprende a construir una aplicación Angular agéntica potenciada por Genkit, Gemini e Imagen 3 para generar dinámicamente una historia basada en la interacción del usuario con hermosos paneles de imagen para acompañar los eventos que ocurren. Comienza aquí si te gustaría experimentar con un caso de uso más avanzado.
 
-  This example also has an in-depth video walkthrough of the functionality:
-    * [Watch "Building Agentic Apps with Angular and Genkit live!"](https://youtube.com/live/mx7yZoIa2n4?feature=share)
-    * [Watch "Building Agentic Apps with Angular and Genkit live! PT 2"](https://youtube.com/live/YR6LN5_o3B0?feature=share)
+  Este ejemplo también tiene un video tutorial en profundidad de la funcionalidad:
+    * [Ver "Building Agentic Apps with Angular and Genkit live!"](https://youtube.com/live/mx7yZoIa2n4?feature=share)
+    * [Ver "Building Agentic Apps with Angular and Genkit live! PT 2"](https://youtube.com/live/YR6LN5_o3B0?feature=share)
 
-* [Building Agentic apps with Firebase and Google Cloud (Barista Example)](https://developers.google.com/solutions/learn/agentic-barista) - Learn how to build an agentic coffee ordering app with Firebase and Google Cloud. This example uses both Firebase AI Logic and Genkit.
+* [Construyendo aplicaciones agénticas con Firebase y Google Cloud (Ejemplo Barista)](https://developers.google.com/solutions/learn/agentic-barista) - Aprende cómo construir una aplicación agéntica de pedidos de café con Firebase y Google Cloud. Este ejemplo usa tanto Firebase AI Logic como Genkit.
 
-### Build AI-powered applications with Firebase AI Logic and Angular
-[Firebase AI Logic](https://firebase.google.com/products/vertex-ai-in-firebase) provides a secure way to interact with Vertex AI Gemini API or Imagen API directly from your web and mobile apps. This is compelling for Angular developers since apps can be either full-stack or client-side only. If you are developing a client-side only application, Firebase AI Logic is a good fit for incorporating AI into your web apps.
+### Construye aplicaciones potenciadas por IA con Firebase AI Logic y Angular
+[Firebase AI Logic](https://firebase.google.com/products/vertex-ai-in-firebase) proporciona una forma segura de interactuar con la API de Vertex AI Gemini o la API de Imagen directamente desde tus aplicaciones web y móviles. Esto es atractivo para los desarrolladores de Angular ya que las aplicaciones pueden ser full-stack o de solo lado del cliente. Si estás desarrollando una aplicación de solo lado del cliente, Firebase AI Logic es una buena opción para incorporar IA en tus aplicaciones web.
 
-Here is an example of how to build with Firebase AI Logic and Angular:
-* [Firebase AI Logic x Angular Starter Kit](https://github.com/angular/examples/tree/main/vertex-ai-firebase-angular-example) - Use this starter-kit to build an e-commerce application with a chat agent that can perform tasks. Start here if you do not have experience building with Firebase AI Logic and Angular.
+Aquí hay un ejemplo de cómo construir con Firebase AI Logic y Angular:
+* [Firebase AI Logic x Angular Starter Kit](https://github.com/angular/examples/tree/main/vertex-ai-firebase-angular-example) - Usa este starter-kit para construir una aplicación de e-commerce con un agente de chat que puede realizar tareas. Comienza aquí si no tienes experiencia construyendo con Firebase AI Logic y Angular.
 
-  This example includes an [in-depth video walkthrough explaining the functionality and demonstrates how to add new features](https://youtube.com/live/4vfDz2al_BI).
+  Este ejemplo incluye un [video tutorial en profundidad explicando la funcionalidad y demuestra cómo agregar nuevas características](https://youtube.com/live/4vfDz2al_BI).
 
-### Build AI-powered applications with Gemini API and Angular
-The [Gemini API](https://ai.google.dev/gemini-api/docs) provides access to state-of-the-art models from Google that support audio, images, video, and text input. These models that are optimized for specific use cases, [learn more on the Gemini API documentation site](https://ai.google.dev/gemini-api/docs/models).
+### Construye aplicaciones potenciadas por IA con Gemini API y Angular
+La [Gemini API](https://ai.google.dev/gemini-api/docs) proporciona acceso a modelos de última generación de Google que soportan entrada de audio, imágenes, video y texto. Estos modelos están optimizados para casos de uso específicos, [aprende más en el sitio de documentación de Gemini API](https://ai.google.dev/gemini-api/docs/models).
 
-* [AI Text Editor Angular app template](https://github.com/FirebaseExtended/firebase-framework-tools/tree/main/starters/angular/ai-text-editor) - Use this template to start with a fully functioning text editor with AI-powered features like refining text, expanding text and formalizing text. This is a good starting point to gain experience with calling the Gemini API via HTTP.
+* [Plantilla de aplicación Angular de Editor de Texto con IA](https://github.com/FirebaseExtended/firebase-framework-tools/tree/main/starters/angular/ai-text-editor) - Usa esta plantilla para comenzar con un editor de texto completamente funcional con características potenciadas por IA como refinar texto, expandir texto y formalizar texto. Este es un buen punto de partida para ganar experiencia llamando a la Gemini API vía HTTP.
 
-* [AI Chatbot app template](https://github.com/FirebaseExtended/firebase-framework-tools/tree/main/starters/angular/ai-chatbot) - This template starts with a chatbot user interface that communicates with the Gemini API via HTTP. 
+* [Plantilla de aplicación de Chatbot con IA](https://github.com/FirebaseExtended/firebase-framework-tools/tree/main/starters/angular/ai-chatbot) - Esta plantilla comienza con una interfaz de usuario de chatbot que se comunica con la Gemini API vía HTTP.
 
-## Best Practices
-### Connecting to model providers and keeping your API Credentials Secure
-When connecting to model providers, it is important to keep your API secrets safe. *Never put your API key in a file that ships to the client, such as `environments.ts`*.
+## Mejores Prácticas
+### Conectarse a proveedores de modelos y mantener tus Credenciales de API Seguras
+Cuando te conectas a proveedores de modelos, es importante mantener tus secretos de API seguros. *Nunca pongas tu clave de API en un archivo que se envía al cliente, como `environments.ts`*.
 
-Your application's architecture determines which AI APIs and tools to choose. Specifically, choose based on whether or not your application is client-side or server-side. Tools such as Firebase AI Logic provide a secure connection to the model APIs for client-side code. If you want to use a different API than Firebase AI Logic or prefer to use a different model provider, consider creating a proxy-server or even [Cloud Functions for Firebase](https://firebase.google.com/docs/functions) to serve as a proxy and not expose your API keys.
+La arquitectura de tu aplicación determina qué APIs y herramientas de IA elegir. Específicamente, elige basándote en si tu aplicación es del lado del cliente o del lado del servidor. Herramientas como Firebase AI Logic proporcionan una conexión segura a las APIs de modelo para código del lado del cliente. Si quieres usar una API diferente a Firebase AI Logic o prefieres usar un proveedor de modelo diferente, considera crear un servidor proxy o incluso [Cloud Functions for Firebase](https://firebase.google.com/docs/functions) para servir como proxy y no exponer tus claves de API.
 
-For an example of connecting using a client-side app, see the code:  [Firebase AI Logic Angular example repository](https://github.com/angular/examples/tree/main/vertex-ai-firebase-angular-example).
+Para un ejemplo de conexión usando una aplicación del lado del cliente, consulta el código: [repositorio de ejemplo de Firebase AI Logic Angular](https://github.com/angular/examples/tree/main/vertex-ai-firebase-angular-example).
 
-For server-side connections to model APIs that require API keys, prefer using a secrets manager or environment variable, not `environments.ts`. You should follow standard best practices for securing API keys and credentials. Firebase now provides a new secrets manager with the latest updates from Firebase App Hosting. To learn more, [check out the official documentation](https://firebase.google.com/docs/app-hosting/configure).
+Para conexiones del lado del servidor a APIs de modelo que requieren claves de API, prefiere usar un gestor de secretos o variable de entorno, no `environments.ts`. Deberías seguir las mejores prácticas estándar para asegurar claves de API y credenciales. Firebase ahora proporciona un nuevo gestor de secretos con las últimas actualizaciones de Firebase App Hosting. Para aprender más, [consulta la documentación oficial](https://firebase.google.com/docs/app-hosting/configure).
 
-For a server-side connection example in a full-stack application, see the code: [Angular AI Example (Genkit and Angular Story Generator) repository](https://github.com/angular/examples/tree/main/genkit-angular-story-generator).
+Para un ejemplo de conexión del lado del servidor en una aplicación full-stack, consulta el código: [repositorio de Angular AI Example (Genkit y Angular Story Generator)](https://github.com/angular/examples/tree/main/genkit-angular-story-generator).
 
-### Use Tool Calling to enhance apps
-If you want to build agentic workflows, where agents are able to act and use tools to solve problems based on prompts use "tool calling". Tool calling, also known as function calling, is a way to provide LLMs the ability to make requests back to the application that called it. As a developer, you define which tools are available and you are in control of how or when the tools are called.
+### Usa Tool Calling para mejorar aplicaciones
+Si quieres construir flujos de trabajo agénticos, donde los agentes pueden actuar y usar herramientas para resolver problemas basados en prompts, usa "tool calling". Tool calling, también conocido como function calling, es una forma de proporcionar a los LLMs la capacidad de hacer solicitudes de vuelta a la aplicación que lo llamó. Como desarrollador, defines qué herramientas están disponibles y tú tienes el control de cómo o cuándo se llaman las herramientas.
 
-Tool calling further enhances your web apps by expanding your AI integration further than a question and answer style chat bot. In fact, you can empower your model to request function calls using the function calling API of your model provider. The available tools can be used to perform more complex actions within the context of your application. 
+Tool calling mejora aún más tus aplicaciones web expandiendo tu integración de IA más allá de un chatbot de estilo pregunta y respuesta. De hecho, puedes empoderar tu modelo para solicitar llamadas a funciones usando la API de function calling de tu proveedor de modelo. Las herramientas disponibles pueden usarse para realizar acciones más complejas dentro del contexto de tu aplicación.
 
-In the [e-commerce example](https://github.com/angular/examples/blob/main/vertex-ai-firebase-angular-example/src/app/ai.service.ts#L88) of the [Angular examples repository](https://github.com/angular/examples), the LLM requests to make calls to functions for inventory in order to gain the necessary context to perform more complex tasks such as calculating how much a group of items in the store will cost. The scope of the available API is up to you as a developer just as is whether or not to call a function requested by the LLM. You remain in control of the flow of execution. You can expose specific functions of a service for example but not all functions of that service.
+En el [ejemplo de e-commerce](https://github.com/angular/examples/blob/main/vertex-ai-firebase-angular-example/src/app/ai.service.ts#L88) del [repositorio de ejemplos de Angular](https://github.com/angular/examples), el LLM solicita hacer llamadas a funciones para inventario con el fin de obtener el contexto necesario para realizar tareas más complejas como calcular cuánto costará un grupo de artículos en la tienda. El alcance de la API disponible depende de ti como desarrollador, al igual que si llamar o no a una función solicitada por el LLM. Permaneces en control del flujo de ejecución. Puedes exponer funciones específicas de un servicio, por ejemplo, pero no todas las funciones de ese servicio.
 
-### Handling non-deterministic responses
-Because models can return non-deterministic results, your applications should be designed with that in mind. Here are a few strategies that you can use in your application implementation:
-* Adjust prompts and model parameters (such as [temperature](https://ai.google.dev/gemini-api/docs/prompting-strategies)) for more or less deterministic responses. You can [find out more in the prompting strategies section](https://ai.google.dev/gemini-api/docs/prompting-strategies) of [ai.google.dev](https://ai.google.dev/).
-* Use the "human in the loop" strategy where a human verifies outputs before proceeding in a workflow. Build your application workflows to allow operators (humans or other models) to verify outputs and confirm key decisions.
-* Employ tool (or function) calling and schema constraints to guide and restrict model responses to predefined formats, increasing response predictability.
+### Manejo de respuestas no determinísticas
+Debido a que los modelos pueden devolver resultados no determinísticos, tus aplicaciones deben diseñarse con eso en mente. Aquí hay algunas estrategias que puedes usar en la implementación de tu aplicación:
+* Ajusta los prompts y parámetros del modelo (como [temperature](https://ai.google.dev/gemini-api/docs/prompting-strategies)) para respuestas más o menos determinísticas. Puedes [descubrir más en la sección de estrategias de prompting](https://ai.google.dev/gemini-api/docs/prompting-strategies) de [ai.google.dev](https://ai.google.dev/).
+* Usa la estrategia "humano en el bucle" donde un humano verifica las salidas antes de proceder en un flujo de trabajo. Construye los flujos de trabajo de tu aplicación para permitir que operadores (humanos u otros modelos) verifiquen salidas y confirmen decisiones clave.
+* Emplea tool calling (o function calling) y restricciones de esquema para guiar y restringir las respuestas del modelo a formatos predefinidos, aumentando la previsibilidad de respuestas.
 
-Even considering these strategies and techniques, sensible fallbacks should be incorporated in your application design. Follow existing standards of application resiliency. For example, it is not acceptable for an application to crash if a resource or API is not available. In that scenario, an error message is displayed to the user and, if applicable, options for next steps are also displayed. Building AI-powered applications requires the same consideration. Confirm that the response is aligned with the expected output and provide a "safe landing" in case it is not aligned by way of [graceful degradation](https://developer.mozilla.org/en-US/docs/Glossary/Graceful_degradation). This also applies to API outages for LLM providers.
+Incluso considerando estas estrategias y técnicas, se deben incorporar alternativas sensatas en el diseño de tu aplicación. Sigue los estándares existentes de resiliencia de aplicación. Por ejemplo, no es aceptable que una aplicación falle si un recurso o API no está disponible. En ese escenario, se muestra un mensaje de error al usuario y, si es aplicable, también se muestran opciones para los siguientes pasos. Construir aplicaciones potenciadas por IA requiere la misma consideración. Confirma que la respuesta esté alineada con la salida esperada y proporciona un "aterrizaje seguro" en caso de que no esté alineada mediante [graceful degradation](https://developer.mozilla.org/en-US/docs/Glossary/Graceful_degradation). Esto también aplica a interrupciones de API de proveedores de LLM.
 
-Consider this example: The LLM provider is not responding. A potential strategy to handle the outage is:
-* Save the response from the user to use in a retry scenario (now or at a later time)
-* Alert the user to the outage with an appropriate message that doesn't reveal sensitive information
-* Resume the conversation at a later time once the services are available again.
+Considera este ejemplo: El proveedor de LLM no está respondiendo. Una estrategia potencial para manejar la interrupción es:
+* Guardar la respuesta del usuario para usar en un escenario de reintento (ahora o en un momento posterior)
+* Alertar al usuario sobre la interrupción con un mensaje apropiado que no revele información sensible
+* Reanudar la conversación en un momento posterior una vez que los servicios estén disponibles nuevamente.
 
-## Next steps
+## Siguientes Pasos
 
-To learn about LLM prompts and AI IDE setup, see the following guides:
+Para aprender sobre prompts de LLM y configuración de IDE con IA, consulta las siguientes guías:
 
 <docs-pill-row>
-  <docs-pill href="ai/develop-with-ai" title="LLM prompts and IDE setup"/>
+  <docs-pill href="ai/develop-with-ai" title="Prompts de LLM y configuración de IDE"/>
 </docs-pill-row>


### PR DESCRIPTION
  Se agregan las traducciones al español para las guías de IA en la sección
  /ai, manteniendo las versiones originales en inglés como archivos .en.md
  para referencia.

  Archivos traducidos:
  - design-patterns.md: patrones de diseño para SDKs de IA y signals
  - develop-with-ai.md: configuración de prompts de LLM e IDE con IA
  - mcp-server-setup.md: configuración del servidor MCP de Angular CLI
  - overview.md: visión general de integración de IA con Angular