### PR TITLE
fix(ci): fix pnpm installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,10 @@ jobs:
           submodules: true
       - name: Setup Node JS
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.17.1
       - name: Setup Bazel
         uses: bazel-contrib/setup-bazel@4fd964a13a440a8aeb0be47350db2fc640f19ca8 # 0.15.0
         with:
@@ -23,9 +27,5 @@ jobs:
           repository-cache: true
       - name: Install Dependencies
         run: npm ci
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10.17.1
       - name: Build Docs
         run: npm run build


### PR DESCRIPTION
El script de build (tools/build.mjs) requiere que pnpm esté disponible
al ejecutar los comandos `pnpm install` y `pnpm bazel build`.
Anteriormente, pnpm se configuraba después de npm ci y antes del build,
lo que causaba que el build fallara porque pnpm no estaba disponible a tiempo.

Cambios:
- Mover el paso "Setup pnpm" para ejecutarse inmediatamente después de "Setup Node JS"
- Asegura que pnpm esté disponible antes de que se ejecuten los comandos de build

Esto corrige el fallo de build donde los comandos pnpm en la función
buildADEV() no podían ejecutarse.