### PR TITLE
docs: remove Twitter and X references

### DIFF
--- a/adev-es/src/app/core/constants/links.ts
+++ b/adev-es/src/app/core/constants/links.ts
@@ -1,10 +1,8 @@
 export const ANGULAR_LINKS = {
     GITHUB: 'https://github.com/angular-hispano/angular-docs-es',
-    X: 'https://x.com/AngularHispana',
     MEDIUM: 'https://blog.angular.dev',
     YOUTUBE: '',
     DISCORD: 'https://discord.gg/4jgk3ddgAx',
     BLUESKY: '',
     STACKOVERFLOW: '',
   } as const;
-  

--- a/adev-es/src/app/core/layout/footer/footer.component.en.html
+++ b/adev-es/src/app/core/layout/footer/footer.component.en.html
@@ -7,9 +7,6 @@
           <a [href]="ngLinks.MEDIUM" title="Angular blog">Blog</a>
         </li>
         <li>
-          <a [href]="ngLinks.X" title="X (formerly Twitter)">X (formerly Twitter)</a>
-        </li>
-        <li>
           <a [href]="ngLinks.BLUESKY" title="Bluesky">Bluesky</a>
         </li>
         <li>

--- a/adev-es/src/app/core/layout/footer/footer.component.html
+++ b/adev-es/src/app/core/layout/footer/footer.component.html
@@ -4,9 +4,6 @@
       <h2>Redes Sociales</h2>
       <ul>
         <li>
-          <a [href]="ngLinks.X" title="X (formerly Twitter)">X (antes Twitter)</a>
-        </li>
-        <li>
           <a
             [href]="ngLinks.DISCORD"
             title="Únase a las discusiones en el servidor de Angular Hispano en Discord."

--- a/adev-es/src/app/core/layout/navigation/navigation.component.en.html
+++ b/adev-es/src/app/core/layout/navigation/navigation.component.en.html
@@ -337,28 +337,6 @@
             </li>
             <li>
               <a
-                [href]="ngLinks.X"
-                cdkMenuItem
-                title="Angular X (formerly Twitter) profile"
-                target="_blank"
-                rel="noopener"
-              >
-                <!-- X Icon -->
-                <svg
-                  width="17"
-                  height="16"
-                  viewBox="0 0 17 16"
-                  fill="none"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M0.04145 0.04432l6.56351 8.77603L0 15.95564h1.48651l5.78263-6.24705 4.6722 6.24705h5.05865l-6.9328-9.26967L16.21504.04432h-1.48651l-5.32552 5.75341L5.1001.04432H.04145Zm2.18602 1.09497h2.32396l10.26221 13.72122h-2.32396L2.22747 1.13928Z"
-                  />
-                </svg>
-              </a>
-            </li>
-            <li>
-              <a
                 [href]="ngLinks.BLUESKY"
                 cdkMenuItem
                 title="Angular Bluesky profile"

--- a/adev-es/src/app/core/layout/navigation/navigation.component.html
+++ b/adev-es/src/app/core/layout/navigation/navigation.component.html
@@ -236,28 +236,6 @@
           <ul class="adev-mini-menu" cdkMenu>
             <li>
               <a
-                [href]="ngLinks.X"
-                cdkMenuItem
-                title="Angular X (formerly Twitter) profile"
-                target="_blank"
-                rel="noopener"
-              >
-                <!-- X Icon -->
-                <svg
-                  width="17"
-                  height="16"
-                  viewBox="0 0 17 16"
-                  fill="none"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M0.04145 0.04432l6.56351 8.77603L0 15.95564h1.48651l5.78263-6.24705 4.6722 6.24705h5.05865l-6.9328-9.26967L16.21504.04432h-1.48651l-5.32552 5.75341L5.1001.04432H.04145Zm2.18602 1.09497h2.32396l10.26221 13.72122h-2.32396L2.22747 1.13928Z"
-                  />
-                </svg>
-              </a>
-            </li>
-            <li>
-              <a
                 [href]="ngLinks.GITHUB"
                 cdkMenuItem
                 title="Angular Github"

--- a/adev-es/src/content/best-practices/update.en.md
+++ b/adev-es/src/content/best-practices/update.en.md
@@ -13,7 +13,7 @@ _AngularJS_ is the name for all v1.x versions of Angular.
 
 ## Getting notified of new releases
 
-To be notified when new releases are available, follow [@angular](https://x.com/angular '@angular on X') on X (formerly Twitter) or subscribe to the [Angular blog](https://blog.angular.dev 'Angular blog').
+To be notified when new releases are available, subscribe to the [Angular blog](https://blog.angular.dev 'Angular blog').
 
 ## Learning about new features
 

--- a/adev-es/src/content/best-practices/update.md
+++ b/adev-es/src/content/best-practices/update.md
@@ -13,7 +13,7 @@ _AngularJS_ es el nombre para todas las versiones v1.x de Angular.
 
 ## Recibiendo notificaciones de nuevos lanzamientos
 
-Para recibir notificaciones cuando nuevos lanzamientos estén disponibles, sigue a [@angular](https://x.com/angular '@angular en X') en X (anteriormente Twitter) o suscríbete al [blog de Angular](https://blog.angular.dev 'Blog de Angular').
+Para recibir notificaciones cuando nuevos lanzamientos estén disponibles, suscríbete al [blog de Angular](https://blog.angular.dev 'Blog de Angular').
 
 ## Aprendiendo sobre nuevas funcionalidades
 


### PR DESCRIPTION
Closes #156.

## Summary
- Remove Angular Hispano X link from shared link constants, footer, and navigation social menu
- Remove X/Twitter release-notification text from the update docs in Spanish and English

## Verification
- `npm ci` with Node 22.22.3
- `git diff --check`
- `rg -n "x\.com|Twitter|twitter|ngLinks\.X|X \(formerly|antes Twitter|anteriormente Twitter|@angular en X|@angular on X" adev-es/src/app/core adev-es/src/content/best-practices/update*.md` returned no matches

Note: I started `npm run build`, but stopped it after it spent ~20 minutes building the full upstream Angular/Bazel production target rather than this repo-specific docs surface.