### PR TITLE
fix(ci): reduce Bazel jobs to 1 to prevent OOM crash

### DIFF
--- a/.github/workflows/adev-staging-deploy.yml
+++ b/.github/workflows/adev-staging-deploy.yml
@@ -34,7 +34,7 @@ jobs:
             # Limit resources for CI runners (ubuntu-latest: 7GB RAM, 2 CPUs)
             build --local_resources=memory=4096
             build --local_resources=cpu=2
-            build --jobs=2
+            build --jobs=1
             build --discard_analysis_cache
             build --nokeep_state_after_build
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,10 @@ jobs:
             # Limit resources for CI runners (ubuntu-latest: 7GB RAM, 2 CPUs)
             build --local_resources=memory=4096
             build --local_resources=cpu=2
-            build --jobs=2
+            build --jobs=1
             build --discard_analysis_cache
             build --nokeep_state_after_build
+            
             # Allow network access in sandbox for Algolia API calls during SSR prerendering.
             build --sandbox_default_allow_network
       - name: Install Dependencies


### PR DESCRIPTION
adev-staging-deploy.yml failed on main with a genuine in-VM OOM
signature (truncated log line + exit code 1) mid-compile at
[17,472/17,628], distinct from the runner-shutdown flakiness seen in
earlier runs. With --jobs=2, two concurrent Bazel actions (ng_package
Rollup bundling, tsc compilation workers) can together exceed the
runner's available memory even though --local_resources=memory=4096
is only a scheduling hint, not a hard cap.

Serializing action execution with --jobs=1 avoids the concurrent
memory spike without lowering the memory budget itself (which
previously pushed build time to ~28min at memory=3072/jobs=2).

Verified against both workflows: the PR check (ci.yml, run 32402548439,
28m25s) and a real push-triggered staging deploy including the
Firebase deploy step (adev-staging-deploy.yml, run 32402468531, 4m9s)
both completed successfully with this change.
